### PR TITLE
Fix XSS in AJAX controller for basket

### DIFF
--- a/share/pnp/application/controllers/ajax.php
+++ b/share/pnp/application/controllers/ajax.php
@@ -2,8 +2,8 @@
 /**
  * Ajax controller.
  *
- * @package    PNP4Nagios 
- * @author     Joerg Linge 
+ * @package    PNP4Nagios
+ * @author     Joerg Linge
  * @license    GPL
  */
 class Ajax_Controller extends System_Controller  {
@@ -15,7 +15,7 @@ class Ajax_Controller extends System_Controller  {
     }
 
     public function index(){
-        url::redirect("start", 302); 
+        url::redirect("start", 302);
     }
 
     public function search() {
@@ -39,14 +39,14 @@ class Ajax_Controller extends System_Controller  {
             $this->session->set('timerange-reset', 1);
         }
     }
-	
+
 	public function filter($what){
         if($what == 'set-sfilter'){
-            $this->session->set('sfilter', $_POST['sfilter']);
+            $this->session->set('sfilter', htmlspecialchars($_POST['sfilter']));
         }elseif($what == 'set-spfilter'){
-			$this->session->set('spfilter', $_POST['spfilter']);
-		}elseif($what == 'set-pfilter'){
-            $this->session->set('pfilter', $_POST['pfilter']);
+            $this->session->set('spfilter', htmlspecialchars($_POST['spfilter']));
+        }elseif($what == 'set-pfilter'){
+            $this->session->set('pfilter', htmlspecialchars($_POST['pfilter']));
         }
     }
 
@@ -72,7 +72,7 @@ class Ajax_Controller extends System_Controller  {
                 }
             }
         }elseif($action == "add"){
-            $item = $_POST['item'];
+            $item = htmlspecialchars($_POST['item']);
             $basket = $this->session->get("basket");
             if(!is_array($basket)){
                 $basket[] = "$item";
@@ -93,7 +93,7 @@ class Ajax_Controller extends System_Controller  {
                       );
             }
         }elseif($action == "sort"){
-            $items = $_POST['items'];
+            $items = htmlspecialchars($_POST['items']);
             $basket = explode(',', $items);
             array_pop($basket);
             $this->session->set("basket", $basket);
@@ -109,7 +109,7 @@ class Ajax_Controller extends System_Controller  {
             }
         }elseif($action == "remove"){
             $basket = $this->session->get("basket");
-            $item_to_remove = $_POST['item'];
+            $item_to_remove = htmlspecialchars($_POST['item']);
             $new_basket = array();
             foreach($basket as $item){
                 if($item ==  $item_to_remove){


### PR DESCRIPTION
 - Before this fix you could send and store arbitrary characters via the basket API and filters
 - Examples:
   - `item="><svg/onclick=alert('foobar')>` in add/basket
   - `sfilters="><svg/onclick=alert('foobar')>`